### PR TITLE
link to whacamole

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Then run `$ bundle install`
 
 ## Turn on Rolling Restarts
 
-A rolling restart will kill each of your workers on a rolling basis. You set the frequency which it conducts the restart. This is a simple way to keep memory down as Ruby web programs generally increase memory usage over time. This is the recommended feature to use if you're using Heroku [where it is difficult to measure RAM from inside of a container accurately](https://github.com/schneems/get_process_mem/issues/7). You can enable roling restarts by running:
+A rolling restart will kill each of your workers on a rolling basis. You set the frequency which it conducts the restart. This is a simple way to keep memory down as Ruby web programs generally increase memory usage over time. If you're using Heroku [it is difficult to measure RAM from inside of a container accurately](https://github.com/schneems/get_process_mem/issues/7), so it is recommended to use this feature or use a [log-drain-based worker killer](https://github.com/arches/whacamole). You can enable roling restarts by running:
 
 ```ruby
 before_fork do


### PR DESCRIPTION
Whacamole is a worker killer that measures Heroku container RAM from outside the container using a log drain