### PR TITLE
Sleep before first reap

### DIFF
--- a/lib/puma_worker_killer/auto_reap.rb
+++ b/lib/puma_worker_killer/auto_reap.rb
@@ -11,8 +11,8 @@ module PumaWorkerKiller
 
       Thread.new do
         while @running
-          @reaper.reap
           sleep @timeout
+          @reaper.reap
         end
       end
     end


### PR DESCRIPTION
When using AutoReap (mainly with the RollingRestart reaper), AutoReap will perform a reap when it is first loaded. This means that when using a the RollingRestart, as soon at the app is launched, a worker will get sent a SIGTERM (due to AutoReap triggering a reap). 

This is pretty pointless, and can sometimes cause issues with workers starting twice for no reason when launching the app.

This change swaps the order the sleep and reap call, meaning that AutoReap will perform a sleep before its first reap, causing less double-starts of puma workers.