### PR TITLE
Configurable reaper status logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ PumaWorkerKiller.config do |config|
   config.frequency     = 5    # seconds
   config.percent_usage = 0.98
   config.rolling_restart_frequency = 12 * 3600 # 12 hours in seconds
+  config.reaper_status_logs = true # setting this to false will not log lines like:
+  # PumaWorkerKiller: Consuming 54.34765625 mb with master and 2 workers.
 end
 PumaWorkerKiller.start
 ```
@@ -147,6 +149,14 @@ PumaWorkerKiller.rolling_restart_frequency = 12 * 3600 # 12 hours in seconds
 ```
 
 By default PumaWorkerKiller will perform a rolling restart of all your worker processes every 12 hours. To disable, set to `false`.
+
+You may want to hide the following log lines: `PumaWorkerKiller: Consuming 54.34765625 mb with master and 2 workers.`. To do that set:
+
+```ruby
+PumaWorkerKiller.reaper_status_logs = false
+```
+
+Note: It is `true` by default.
 
 ## License
 

--- a/lib/puma_worker_killer.rb
+++ b/lib/puma_worker_killer.rb
@@ -3,18 +3,19 @@ require 'get_process_mem'
 module PumaWorkerKiller
   extend self
 
-  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency
+  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency, :reaper_status_logs
   self.ram           = 512  # mb
   self.frequency     = 10   # seconds
   self.percent_usage = 0.99 # percent of RAM to use
   self.rolling_restart_frequency = 6 * 3600 # 6 hours in seconds
+  self.reaper_status_logs = true
 
   def config
     yield self
   end
 
-  def reaper(ram = self.ram, percent = self.percent_usage)
-    Reaper.new(ram * percent_usage)
+  def reaper(ram = self.ram, percent = self.percent_usage, reaper_status_logs = self.reaper_status_logs)
+    Reaper.new(ram * percent_usage, nil, reaper_status_logs)
   end
 
   def start(frequency = self.frequency, reaper = self.reaper)

--- a/lib/puma_worker_killer/reaper.rb
+++ b/lib/puma_worker_killer/reaper.rb
@@ -1,8 +1,9 @@
 module PumaWorkerKiller
   class Reaper
-    def initialize(max_ram, master = nil)
+    def initialize(max_ram, master = nil, reaper_status_logs = true)
       @cluster = PumaWorkerKiller::PumaMemory.new(master)
       @max_ram = max_ram
+      @reaper_status_logs = reaper_status_logs
     end
 
     # used for tes
@@ -15,7 +16,7 @@ module PumaWorkerKiller
       if (total = get_total_memory) > @max_ram
         @cluster.master.log "PumaWorkerKiller: Out of memory. #{@cluster.workers.count} workers consuming total: #{total} mb out of max: #{@max_ram} mb. Sending TERM to pid #{@cluster.largest_worker.pid} consuming #{@cluster.largest_worker_memory} mb."
         @cluster.term_largest_worker
-      else
+      elsif @reaper_status_logs
         @cluster.master.log "PumaWorkerKiller: Consuming #{total} mb with master and #{@cluster.workers.count} workers."
       end
     end

--- a/test/puma_worker_killer_test.rb
+++ b/test/puma_worker_killer_test.rb
@@ -43,7 +43,7 @@ class PumaWorkerKillerTest < Test::Unit::TestCase
     port     = 0
     command  = "bundle exec puma #{ file } -t 1:1 -w 2 --preload --debug -p #{ port }"
     puts command.inspect
-    options  = { wait_for: "booted", timeout: 10, env: { } }
+    options  = { wait_for: "booted", timeout: 15, env: { } }
 
     WaitForIt.new(command, options) do |spawn|
       assert_contains(spawn, "Rolling Restart")


### PR DESCRIPTION
Status lines like `PumaWorkerKiller: Consuming 54.34765625 mb with master and 2 workers.` fill up the puma logs pretty quickly.

This pull request adds a configuration option to optionally hide the status logs that Reaper displays every iteration.