### PR TITLE
Add support for Heroku log-runtime-metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+
+- Heroku log-runtime-metrics is supported.
+
 ## 0.1.0
 
 - Emit extra data via `pre_term` callback before puma worker killer terminates a worker #49.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ $ heroku labs:enable log-runtime-metrics --app YOUR_APP_NAME
 Next, get your app's Heroku auth token:
 
 ```bash
-$ heroku auth:token
+$ heroku auth:token # for a one-year token
+# or...
+$ heroku authorizations:create # for a long-lived token
 ```
 
 Then, set these variables in your Heroku config.

--- a/lib/puma_worker_killer.rb
+++ b/lib/puma_worker_killer.rb
@@ -3,13 +3,15 @@ require 'get_process_mem'
 module PumaWorkerKiller
   extend self
 
-  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency, :reaper_status_logs, :pre_term
+  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency, :reaper_status_logs, :pre_term, :heroku_api_token, :heroku_app_name
   self.ram           = 512  # mb
   self.frequency     = 10   # seconds
   self.percent_usage = 0.99 # percent of RAM to use
   self.rolling_restart_frequency = 6 * 3600 # 6 hours in seconds
   self.reaper_status_logs = true
   self.pre_term = lambda { |_| } # nop
+  self.heroku_api_token = nil
+  self.heroku_app_name = nil
 
   def config
     yield self
@@ -34,4 +36,6 @@ require 'puma_worker_killer/puma_memory'
 require 'puma_worker_killer/reaper'
 require 'puma_worker_killer/rolling_restart'
 require 'puma_worker_killer/auto_reap'
+require 'puma_worker_killer/heroku_wrapper'
+require 'puma_worker_killer/stream'
 require 'puma_worker_killer/version'

--- a/lib/puma_worker_killer/heroku_wrapper.rb
+++ b/lib/puma_worker_killer/heroku_wrapper.rb
@@ -1,0 +1,48 @@
+require 'base64'
+require 'net/http'
+require 'json'
+
+module PumaWorkerKiller
+  class HerokuWrapper
+    attr_accessor :heroku_api_token, :app_name
+
+    def initialize(app_name, heroku_api_token)
+      self.app_name = app_name
+      self.heroku_api_token = heroku_api_token
+    end
+
+    def create_log_session
+      uri = URI(log_sessions_url)
+      req = Net::HTTP::Post.new(uri.path)
+      req['Authorization'] = authorization
+      req['Content-type'] = content_type
+      req['Accept'] = accept
+      req.set_form_data(
+        {
+          tail: true,
+          source: 'heroku',
+          dyno: ENV['DYNO'] || 'web.1'
+        }
+      )
+      res = Net::HTTP.start(uri.host, uri.port, use_ssl: (uri.scheme == "https")) {|http| http.request(req)}
+      JSON.parse(res.body)['logplex_url']
+    end
+
+    def authorization
+      "Basic " + Base64.encode64(":#{heroku_api_token}").gsub("\n", '')
+    end
+
+    private
+    def content_type
+      "application/json"
+    end
+
+    def accept
+      "application/vnd.heroku+json; version=3"
+    end
+
+    def log_sessions_url
+      "https://api.heroku.com/apps/#{app_name}/log-sessions"
+    end
+  end
+end

--- a/lib/puma_worker_killer/puma_memory.rb
+++ b/lib/puma_worker_killer/puma_memory.rb
@@ -55,7 +55,7 @@ module PumaWorkerKiller
       if PumaWorkerKiller.heroku_api_token
         heroku = HerokuWrapper.new(PumaWorkerKiller.heroku_app_name, PumaWorkerKiller.heroku_api_token)
         stream_url = heroku.create_log_session
-        Stream.new(stream_url).watch
+        Stream.new(stream_url).watch rescue 0.0
       else
         master_memory = GetProcessMem.new(Process.pid).mb
         worker_memory = workers.map {|_, mem| mem }.inject(&:+) || 0

--- a/lib/puma_worker_killer/puma_memory.rb
+++ b/lib/puma_worker_killer/puma_memory.rb
@@ -52,9 +52,15 @@ module PumaWorkerKiller
 
     # Will refresh @workers
     def get_total(workers = set_workers)
-      master_memory = GetProcessMem.new(Process.pid).mb
-      worker_memory = workers.map {|_, mem| mem }.inject(&:+) || 0
-      worker_memory + master_memory
+      if PumaWorkerKiller.heroku_api_token
+        heroku = HerokuWrapper.new(PumaWorkerKiller.heroku_app_name, PumaWorkerKiller.heroku_api_token)
+        stream_url = heroku.create_log_session
+        Stream.new(stream_url).watch
+      else
+        master_memory = GetProcessMem.new(Process.pid).mb
+        worker_memory = workers.map {|_, mem| mem }.inject(&:+) || 0
+        worker_memory + master_memory
+      end
     end
     alias :get_total_memory :get_total
 

--- a/lib/puma_worker_killer/stream.rb
+++ b/lib/puma_worker_killer/stream.rb
@@ -1,0 +1,35 @@
+require 'net/http'
+
+module PumaWorkerKiller
+
+  class Stream
+
+    def initialize(url)
+      @url = url
+    end
+
+    def watch
+      uri = URI(url)
+      Net::HTTP.start(uri.host, uri.port, use_ssl: uri.scheme == 'https') do |http|
+        request = Net::HTTP::Get.new(uri.request_uri)
+        http.request(request) do |response|
+          response.read_body do |chunk|
+            return memory_size_from_chunk(chunk) || 0.0
+          end
+        end
+      end
+    end
+
+    private
+
+    def memory_size_from_chunk(chunk)
+      line = chunk.split("\n").select{|line| line.include? 'sample#memory_total'}.last || 'no line'
+      size = line.match(/sample#memory_total=([\d\.]+)/) || [nil, 0.0]
+      return size[1].to_f
+    end
+
+    def url
+      @url
+    end
+  end
+end

--- a/lib/puma_worker_killer/version.rb
+++ b/lib/puma_worker_killer/version.rb
@@ -1,3 +1,3 @@
 module PumaWorkerKiller
-  VERSION = "0.1.0"
+  VERSION = "0.2.0"
 end

--- a/test/fixtures/fixture_helper.rb
+++ b/test/fixtures/fixture_helper.rb
@@ -6,8 +6,10 @@ require 'rack/server'
 require 'puma_worker_killer'
 
 PumaWorkerKiller.config do |config|
-  config.ram       = Integer(ENV['PUMA_RAM'])       if ENV['PUMA_RAM']
-  config.frequency = Integer(ENV['PUMA_FREQUENCY']) if ENV['PUMA_FREQUENCY']
+  config.ram              = Integer(ENV['PUMA_RAM'])        if ENV['PUMA_RAM']
+  config.frequency        = Integer(ENV['PUMA_FREQUENCY'])  if ENV['PUMA_FREQUENCY']
+  config.heroku_app_name  = String(ENV['APP_NAME_HEROKU'])  if ENV['APP_NAME_HEROKU']
+  config.heroku_api_token = String(ENV['API_TOKEN_HEROKU']) if ENV['API_TOKEN_HEROKU']
 end
 
 puts "Frequency: #{ PumaWorkerKiller.frequency }" if ENV['PUMA_FREQUENCY']

--- a/test/puma_worker_killer_test.rb
+++ b/test/puma_worker_killer_test.rb
@@ -61,4 +61,14 @@ class PumaWorkerKillerTest < Test::Unit::TestCase
       assert_contains(spawn, "Rolling Restart")
     end
   end
+
+  def test_api_token
+    port     = 0 # http://stackoverflow.com/questions/200484/how-do-you-find-a-free-tcp-server-port-using-ruby
+    command  = "bundle exec puma #{ fixture_path.join("default.ru") } -t 1:1 -w 2 --preload --debug -p #{ port }"
+    options  = { wait_for: "booted", timeout: 15, env: { 'APP_NAME_HEROKU' => 'fake-app-name', 'API_TOKEN_HEROKU' => 'fake-api-token' } }
+
+    WaitForIt.new(command, options) do |spawn|
+      assert_contains(spawn, "Consuming 0.0 mb")
+    end
+  end
 end


### PR DESCRIPTION
This PR uses code from the [whacamole](https://github.com/arches/whacamole) gem, modified to fit PWK. If you provide a Heroku API token in your config, then instead of attempting to measure total memory use directly PWK will get it from your Heroku logs with an HTTP request. This PR doesn't change existing operation until a Heroku API token is added to `PumaWorkerKiller.config`.

If the HTTP request does not return any memory info, the `get_total` method will return 0.0 instead of raising an exception, so nothing blows up. Generally, the next request will return valid memory information.

Note that this PR requires log-runtime-metrics and the `DYNO` environment variable, both of which are Heroku beta features. Again, though, nothing blows up if they stop working. Worst-case scenario is if Heroku removes these features and your app still has a Heroku API token in `PumaWorkerKiller.config`, the app will continue to run but PWK will not work.

There are no new tests, because I don't know how to test these features. Existing tests pass locally.