### PR TITLE
Add optional setting to configure delay between worker reaps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,14 @@ or you can pass in the restart frequency:
 PumaWorkerKiller.enable_rolling_restart(12 * 3600) # 12 hours in seconds
 ```
 
+If you would like to introduce a custom delay between worker restarts:
+```ruby
+# Rolling restart every 12hrs, 120 second period between worker terminations.
+PumaWorkerKiller.enable_rolling_restart(12 * 3600, 120) 
+```
+This is useful if your workers have a `on_worker_shutdown` routine that takes some
+period of time. The default is 60 seconds to avoid all workers being shut down at once.
+
 Make sure if you do this to not accidentally call `PumaWorkerKiller.start` as well.
 
 ## Enable Worker Killing

--- a/lib/puma_worker_killer.rb
+++ b/lib/puma_worker_killer.rb
@@ -3,19 +3,23 @@ require 'get_process_mem'
 module PumaWorkerKiller
   extend self
 
-  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency, :reaper_status_logs, :pre_term
-  self.ram           = 512  # mb
-  self.frequency     = 10   # seconds
-  self.percent_usage = 0.99 # percent of RAM to use
-  self.rolling_restart_frequency = 6 * 3600 # 6 hours in seconds
-  self.reaper_status_logs = true
-  self.pre_term = lambda { |_| } # nop
+  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency,
+                :rolling_restart_kill_delay, :reaper_status_logs, :pre_term
+  self.ram                        = 512 # mb
+  self.frequency                  = 10 # seconds
+  self.percent_usage              = 0.99 # percent of RAM to use
+  self.rolling_restart_kill_delay = 60 # seconds, interval between worker kills
+  self.rolling_restart_frequency  = 6 * 3600 # 6 hours in seconds
+  self.reaper_status_logs         = true
+  self.pre_term                   = lambda { |_| } # nop
 
   def config
     yield self
   end
 
-  def reaper(ram = self.ram, percent = self.percent_usage, reaper_status_logs = self.reaper_status_logs, pre_term = self.pre_term)
+  def reaper(ram = self.ram, percent = self.percent_usage,
+             reaper_status_logs = self.reaper_status_logs,
+             pre_term = self.pre_term)
     Reaper.new(ram * percent_usage, nil, reaper_status_logs, pre_term)
   end
 
@@ -24,9 +28,12 @@ module PumaWorkerKiller
     enable_rolling_restart(rolling_restart_frequency) if rolling_restart_frequency
   end
 
-  def enable_rolling_restart(frequency = self.rolling_restart_frequency)
-    frequency = frequency + rand(0..10.0) # so all workers don't restart at the exact same time across multiple machines
-    AutoReap.new(frequency, RollingRestart.new).start
+  def enable_rolling_restart(frequency = self.rolling_restart_frequency,
+                             kill_delay = self.rolling_restart_kill_delay)
+    # so all workers don't restart at the exact same time across multiple machines
+    frequency = frequency + rand(0..10.0)
+    reaper    = RollingRestart.new(kill_delay: kill_delay)
+    AutoReap.new(frequency, reaper).start
   end
 end
 

--- a/lib/puma_worker_killer.rb
+++ b/lib/puma_worker_killer.rb
@@ -32,7 +32,7 @@ module PumaWorkerKiller
                              kill_delay = self.rolling_restart_kill_delay)
     # so all workers don't restart at the exact same time across multiple machines
     frequency = frequency + rand(0..10.0)
-    reaper    = RollingRestart.new(kill_delay: kill_delay)
+    reaper    = RollingRestart.new(kill_delay)
     AutoReap.new(frequency, reaper).start
   end
 end

--- a/lib/puma_worker_killer/auto_reap.rb
+++ b/lib/puma_worker_killer/auto_reap.rb
@@ -16,6 +16,5 @@ module PumaWorkerKiller
         end
       end
     end
-
   end
 end

--- a/lib/puma_worker_killer/rolling_restart.rb
+++ b/lib/puma_worker_killer/rolling_restart.rb
@@ -2,7 +2,7 @@ module PumaWorkerKiller
   class RollingRestart
     # Reap workers with an optional delay between terminations
     # to avoid all workers being killed at once.
-    def initialize(kill_delay: 60, master: nil)
+    def initialize(kill_delay = 60, master = nil)
       @cluster = PumaWorkerKiller::PumaMemory.new(master)
       @kill_delay = kill_delay
     end

--- a/lib/puma_worker_killer/rolling_restart.rb
+++ b/lib/puma_worker_killer/rolling_restart.rb
@@ -1,7 +1,10 @@
 module PumaWorkerKiller
   class RollingRestart
-    def initialize(master = nil)
+    # Reap workers with an optional delay between terminations
+    # to avoid all workers being killed at once.
+    def initialize(kill_delay: 60, master: nil)
       @cluster = PumaWorkerKiller::PumaMemory.new(master)
+      @kill_delay = kill_delay
     end
 
     # used for tes
@@ -9,12 +12,12 @@ module PumaWorkerKiller
       @cluster.get_total_memory
     end
 
-    def reap(wait_between_worker_kill = 60) # seconds
+    def reap
       return false unless @cluster.running?
       @cluster.workers.each do |worker, ram|
         @cluster.master.log "PumaWorkerKiller: Rolling Restart. #{@cluster.workers.count} workers consuming total: #{ get_total_memory } mb. Sending TERM to pid #{worker.pid}."
         worker.term
-        sleep wait_between_worker_kill
+        sleep @kill_delay
       end
     end
   end


### PR DESCRIPTION
I had an application that had a several minutes long `on_worker_shutdown` routine. The period between worker terminations was not user configurable and defaulted to 60 seconds. This left me in the situation where all my workers would then be sent `TERM` before they completed and spawned another. My application was then not responding until at least one worker completed.

This PR adds a user configurable delay between worker kills. I am not sure how useful this is for others, but I figured I'd offer it up for inclusion.