### PR TITLE
avoid terminating workers which have been terminated last time

### DIFF
--- a/lib/puma_worker_killer/rolling_restart.rb
+++ b/lib/puma_worker_killer/rolling_restart.rb
@@ -10,9 +10,12 @@ module PumaWorkerKiller
     end
 
     def reap(wait_between_worker_kill = 60) # seconds
+      # this will implicitly call set_workers
+      total_memory = get_total_memory
       return false unless @cluster.running?
+
       @cluster.workers.each do |worker, ram|
-        @cluster.master.log "PumaWorkerKiller: Rolling Restart. #{@cluster.workers.count} workers consuming total: #{ get_total_memory } mb. Sending TERM to pid #{worker.pid}."
+        @cluster.master.log "PumaWorkerKiller: Rolling Restart. #{@cluster.workers.count} workers consuming total: #{ total_memory } mb. Sending TERM to pid #{worker.pid}."
         worker.term
         sleep wait_between_worker_kill
       end


### PR DESCRIPTION
the rolling restart will only update its worker list when calling
get_total_memory (which implicity fetch the updated worker list from
puma). That's why the next time it perform reaps it still see the same
copies of workers as last time saw.

It's related to issue #46 