### PR TITLE
Bump puma dependency to v4

### DIFF
--- a/puma_worker_killer.gemspec
+++ b/puma_worker_killer.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "puma",              ">= 2.7", "< 4"
+  gem.add_dependency "puma",              ">= 2.7", "< 5"
   gem.add_dependency "get_process_mem",   "~>  0.2"
   gem.add_development_dependency "rack", "~> 1.6"
   gem.add_development_dependency "wait_for_it", "~> 0.1"


### PR DESCRIPTION
I checked on our staging env and it is working without any error with puma v4.0.0. Fixes #71 