### PR TITLE
fix @workers not initialized warning

### DIFF
--- a/lib/puma_worker_killer/puma_memory.rb
+++ b/lib/puma_worker_killer/puma_memory.rb
@@ -2,6 +2,7 @@ module PumaWorkerKiller
   class PumaMemory
     def initialize(master = nil)
       @master  = master || get_master
+      @workers = nil
     end
 
     def master


### PR DESCRIPTION
A warning occurred when running  `rake` with `RUBYOPT=-w`.

```
/Users/pocari/repos/github.com/pocari/puma_worker_killer/lib/puma_worker_killer/puma_memory.rb:62: warning: instance variable @workers not initialized
```

I fixed it.