### PR TITLE
Simplify worker_memory calculation in get_total

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Master
+
+- Simplify workers memory calculation in PumaMemory‘s `get_total` method #81
+
 ## 0.1.1
 
 - Allow PWK to be used with Puma 4 (#72)

--- a/lib/puma_worker_killer/puma_memory.rb
+++ b/lib/puma_worker_killer/puma_memory.rb
@@ -54,7 +54,7 @@ module PumaWorkerKiller
     # Will refresh @workers
     def get_total(workers = set_workers)
       master_memory = GetProcessMem.new(Process.pid).mb
-      worker_memory = workers.map {|_, mem| mem }.inject(&:+) || 0
+      worker_memory = workers.values.sum
       worker_memory + master_memory
     end
     alias :get_total_memory :get_total


### PR DESCRIPTION
Hello 👋 

I was playing with this and notice we could simplify the calculation of workers‘ memory a little bit. This also makes it a little bit faster 💨 

☺️ 