### PR TITLE
Add rolling_pre_term config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Master
 
 - Simplify workers memory calculation in PumaMemory‘s `get_total` method #81
+- Add `pre_term`-like `rolling_pre_term` config for terminations caused by rolling restart #83
 
 ## 0.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## Master
 
 - Simplify workers memory calculation in PumaMemory‘s `get_total` method #81
-- Add `pre_term`-like `rolling_pre_term` config for terminations caused by rolling restart #83
+- Add `pre_term`-like `rolling_pre_term` config for terminations caused by rolling restart (#86)
 
 ## 0.1.1
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ PumaWorkerKiller.config do |config|
   # PumaWorkerKiller: Consuming 54.34765625 mb with master and 2 workers.
 
   config.pre_term = -> (worker) { puts "Worker #{worker.inspect} being killed" }
+  config.rolling_pre_term = -> (worker) { puts "Worker #{worker.inspect} being killed by rolling restart" }
 end
 PumaWorkerKiller.start
 ```
@@ -138,6 +139,17 @@ PumaWorkerKiller: Rolling Restart. 5 workers consuming total: 650mb mb. Sending 
 ```
 
 However you may want to collect more data, such as sending an event to an error collection service like rollbar or airbrake. The `pre_term` lambda gets called before any worker is killed by PWK for any reason.
+
+### rolling_pre_term
+
+`config.rolling_pre_term` will be called just prior to worker termination by rolling restart when rolling restart is enabled.
+
+It is similar to `config.pre_term`.
+
+Difference:
+
+- `config.pre_term` is triggered only by terminations related with exceeding RAM
+- `config.rolling_pre_term` is triggered only by terminations caused by enabled rolling restart
 
 ### on_calculation
 

--- a/lib/puma_worker_killer.rb
+++ b/lib/puma_worker_killer.rb
@@ -3,13 +3,16 @@ require 'get_process_mem'
 module PumaWorkerKiller
   extend self
 
-  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency, :reaper_status_logs, :pre_term, :on_calculation
+  attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency,
+                :reaper_status_logs, :pre_term, :rolling_pre_term, :on_calculation
+
   self.ram           = 512  # mb
   self.frequency     = 10   # seconds
   self.percent_usage = 0.99 # percent of RAM to use
   self.rolling_restart_frequency = 6 * 3600 # 6 hours in seconds
   self.reaper_status_logs = true
   self.pre_term = nil
+  self.rolling_pre_term = nil
   self.on_calculation = nil
 
   def config
@@ -27,7 +30,7 @@ module PumaWorkerKiller
 
   def enable_rolling_restart(frequency = self.rolling_restart_frequency)
     frequency = frequency + rand(0..10.0) # so all workers don't restart at the exact same time across multiple machines
-    AutoReap.new(frequency, RollingRestart.new).start
+    AutoReap.new(frequency, RollingRestart.new(nil, self.rolling_pre_term)).start
   end
 end
 

--- a/lib/puma_worker_killer/rolling_restart.rb
+++ b/lib/puma_worker_killer/rolling_restart.rb
@@ -1,7 +1,8 @@
 module PumaWorkerKiller
   class RollingRestart
-    def initialize(master = nil)
+    def initialize(master = nil, rolling_pre_term = nil)
       @cluster = PumaWorkerKiller::PumaMemory.new(master)
+      @rolling_pre_term = rolling_pre_term
     end
 
     # used for tes
@@ -16,6 +17,7 @@ module PumaWorkerKiller
 
       @cluster.workers.each do |worker, ram|
         @cluster.master.log "PumaWorkerKiller: Rolling Restart. #{@cluster.workers.count} workers consuming total: #{ total_memory } mb. Sending TERM to pid #{worker.pid}."
+        @rolling_pre_term.call(worker) unless @rolling_pre_term.nil?
         worker.term
         sleep wait_between_worker_kill
       end

--- a/test/fixtures/rolling_pre_term.ru
+++ b/test/fixtures/rolling_pre_term.ru
@@ -1,0 +1,8 @@
+load File.expand_path("../fixture_helper.rb", __FILE__)
+
+PumaWorkerKiller.config do |config|
+  config.rolling_pre_term = lambda { |worker| puts("About to terminate (rolling) worker: #{worker.pid}") }
+end
+PumaWorkerKiller.enable_rolling_restart(1) # 1 second
+
+run HelloWorldApp

--- a/test/puma_worker_killer_test.rb
+++ b/test/puma_worker_killer_test.rb
@@ -88,4 +88,17 @@ class PumaWorkerKillerTest < Test::Unit::TestCase
       assert term_ids.sort == term_ids.uniq.sort
     end
   end
+
+  def test_rolling_pre_term
+    file     = fixture_path.join("rolling_pre_term.ru")
+    port     = 0
+    command  = "bundle exec puma #{ file } -t 1:1 -w 2 --preload --debug -p #{ port }"
+    puts command.inspect
+    options  = { wait_for: "booted", timeout: 15, env: { } }
+
+    WaitForIt.new(command, options) do |spawn|
+      assert_contains(spawn, "Rolling Restart")
+      assert_contains(spawn, "About to terminate (rolling) worker:") # defined in rolling_pre_term.ru
+    end
+  end
 end


### PR DESCRIPTION
### Description
I was faced with the need to perform some actions on worker termination by rolling restart on Heroku.
It turns out I'm not alone, see https://github.com/schneems/puma_worker_killer/issues/83
Existing `pre_term` config gives a possibility to such a thing, but only for termination caused by exceeding accepted RAM level.

This PR brings new config `rolling_pre_term` accepting a lambda (as `pre_term`) that will be called just prior to worker termination by rolling restart when rolling restart is enabled.

### Usage
```ruby
PumaWorkerKiller.config do |config|
  config.rolling_pre_term = lambda do |worker|
    puts "Terminating worker #{worker.pid} at #{Time.now}"
  end
end
```