### PR TITLE
Refine worker termination and rolling restart log messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## Main
 
+## 0.3.2
+
+- Refine worker termination and rolling restart event logs
+
 ## 0.3.1
 
 - Relax puma dependency (#94)

--- a/README.md
+++ b/README.md
@@ -129,13 +129,13 @@ PumaWorkerKiller.start
 By default Puma Worker Killer will emit a log when a worker is being killed
 
 ```
-PumaWorkerKiller: Out of memory. 5 workers consuming total: 500 mb out of max: 450 mb. Sending TERM to pid 23 consuming 53 mb.
+PumaWorkerKiller: Out of memory. 5 workers and master consuming total: 500 mb out of max: 450 mb. Sending TERM to pid 23 consuming 53 mb.
 ```
 
 or
 
 ```
-PumaWorkerKiller: Rolling Restart. 5 workers consuming total: 650mb mb. Sending TERM to pid 34.
+PumaWorkerKiller: Rolling Restart. 5 workers and master consuming total: 650mb mb. Sending TERM to pid 34.
 ```
 
 However you may want to collect more data, such as sending an event to an error collection service like rollbar or airbrake. The `pre_term` lambda gets called before any worker is killed by PWK for any reason.

--- a/lib/puma_worker_killer/reaper.rb
+++ b/lib/puma_worker_killer/reaper.rb
@@ -22,7 +22,7 @@ module PumaWorkerKiller
       @on_calculation&.call(total)
 
       if total > @max_ram
-        @cluster.master.log "PumaWorkerKiller: Out of memory. #{@cluster.workers.count} workers consuming total: #{total} mb out of max: #{@max_ram} mb. Sending TERM to pid #{@cluster.largest_worker.pid} consuming #{@cluster.largest_worker_memory} mb."
+        @cluster.master.log "PumaWorkerKiller: Out of memory. #{@cluster.workers.count} workers and master consuming total: #{total} mb out of max: #{@max_ram} mb. Sending TERM to pid #{@cluster.largest_worker.pid} consuming #{@cluster.largest_worker_memory} mb."
 
         # Fetch the largest_worker so that both `@pre_term` and `term_worker` are called with the same worker
         # Avoids a race condition where:

--- a/lib/puma_worker_killer/rolling_restart.rb
+++ b/lib/puma_worker_killer/rolling_restart.rb
@@ -18,7 +18,7 @@ module PumaWorkerKiller
       return false unless @cluster.running?
 
       @cluster.workers.each do |worker, _ram|
-        @cluster.master.log "PumaWorkerKiller: Rolling Restart. #{@cluster.workers.count} workers consuming total: #{total_memory} mb. Sending TERM to pid #{worker.pid}."
+        @cluster.master.log "PumaWorkerKiller: Rolling Restart. #{@cluster.workers.count} workers and master consuming total: #{total_memory} mb. Sending TERM to pid #{worker.pid}."
         @rolling_pre_term&.call(worker)
 
         worker.term

--- a/lib/puma_worker_killer/version.rb
+++ b/lib/puma_worker_killer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PumaWorkerKiller
-  VERSION = '0.3.1'
+  VERSION = '0.3.2'
 end


### PR DESCRIPTION
Clarifies that total memory is consumed by all workers AND the master process in the log messages.   
  
I found the current message a bit misleading, as it could drive to the conclusion that the listed amount of memory consumed by workers only. My suggestion is to refine it, mentioning the master.  

The only concern that somebody may parse this message in the code, so it could lead to incompatibility for them. On the other hand, it's not the best practice to do that, and the gem provides the ability to configure hooks for such events.  