### PR TITLE
fix: Avoid crashing if not in cluster mode

### DIFF
--- a/lib/puma_worker_killer/puma_memory.rb
+++ b/lib/puma_worker_killer/puma_memory.rb
@@ -71,7 +71,7 @@ module PumaWorkerKiller
     # sorted by memory ascending (smallest first, largest last)
     def set_workers
       workers = {}
-      @master.instance_variable_get(:@workers).each do |worker|
+      Array(@master.instance_variable_get(:@workers)).each do |worker|
         workers[worker] = GetProcessMem.new(worker.pid).mb
       end
       if workers.any?


### PR DESCRIPTION
If PumaWorkerKiller is enabled, but Puma isn't in cluster mode (no workers), after roughly six hours, it crashes:
```
#<Thread:0x00007fdcbc998ef0 /Users/jcw/.rvm/gems/ruby-2.7.6/gems/puma_worker_killer-0.3.1/lib/puma_worker_killer/auto_reap.rb:14 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	4: from /Users/jcw/.rvm/gems/ruby-2.7.6/gems/puma_worker_killer-0.3.1/lib/puma_worker_killer/auto_reap.rb:17:in `block in start'
	3: from /Users/jcw/.rvm/gems/ruby-2.7.6/gems/puma_worker_killer-0.3.1/lib/puma_worker_killer/rolling_restart.rb:17:in `reap'
	2: from /Users/jcw/.rvm/gems/ruby-2.7.6/gems/puma_worker_killer-0.3.1/lib/puma_worker_killer/rolling_restart.rb:12:in `get_total_memory'
	1: from /Users/jcw/.rvm/gems/ruby-2.7.6/gems/puma_worker_killer-0.3.1/lib/puma_worker_killer/puma_memory.rb:53:in `get_total'
/Users/jcw/.rvm/gems/ruby-2.7.6/gems/puma_worker_killer-0.3.1/lib/puma_worker_killer/puma_memory.rb:75:in `set_workers': undefined method `each' for nil:NilClass (NoMethodError)
```

While it's true that this plugin doesn't make sense to run unless there's workers to monitor, in case someone does, this PR fixes the crash.