### PR TITLE
Update Gemspec versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,9 @@ jobs:
       fail-fast: false
       matrix:
         ruby:
-          - 2.3
-          - 2.4
-          - 2.5
-          - 2.6
-          - 2.7
-          - '3.0'
           - 3.1
+          - 3.2
+          - 3.3
           - head
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,8 +23,8 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
-      - name: rubocop
-        run: bundle exec rubocop
+      - name: Ruby linting
+        run: bundle exec standardrb
       - name: test
         run: bundle exec rake test
         continue-on-error: ${{ matrix.ruby == 'head' }}

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,0 +1,1 @@
+ruby_version: 3.0       # default: RUBY_VERSION

--- a/.standard.yml
+++ b/.standard.yml
@@ -1,1 +1,1 @@
-ruby_version: 3.0       # default: RUBY_VERSION
+ruby_version: 3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Main
 
+- Add `bigdecimal` as a dependency (https://github.com/zombocom/puma_worker_killer/pull/109)
+- Ruby versions prior to 3.1 may no longer work (https://github.com/zombocom/puma_worker_killer/pull/109)
 - Migrate CI from Travis CI to GitHub Actions (#101)
 
 ## 0.3.1

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source 'https://rubygems.org'
+source "https://rubygems.org"
 
 gemspec
 

--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ source 'https://rubygems.org'
 gemspec
 
 # This is the last version which supports Ruby 2.3
-gem 'rubocop', '~> 0.81.0', require: false
+gem "standard"

--- a/Rakefile
+++ b/Rakefile
@@ -1,15 +1,15 @@
 # frozen_string_literal: true
 
-require 'bundler/gem_tasks'
+require "bundler/gem_tasks"
 
-require 'rake'
-require 'rake/testtask'
+require "rake"
+require "rake/testtask"
 
-task :default => [:test]
+task default: [:test]
 
 Rake::TestTask.new(:test) do |t|
-  t.libs << 'lib'
-  t.libs << 'test'
-  t.pattern = 'test/**/*_test.rb'
+  t.libs << "lib"
+  t.libs << "test"
+  t.pattern = "test/**/*_test.rb"
   t.verbose = false
 end

--- a/lib/puma_worker_killer.rb
+++ b/lib/puma_worker_killer.rb
@@ -1,16 +1,16 @@
 # frozen_string_literal: true
 
-require 'get_process_mem'
+require "get_process_mem"
 
 module PumaWorkerKiller
   extend self
 
   attr_accessor :ram, :frequency, :percent_usage, :rolling_restart_frequency,
-                :rolling_restart_splay_seconds,
-                :reaper_status_logs, :pre_term, :rolling_pre_term, :on_calculation
+    :rolling_restart_splay_seconds,
+    :reaper_status_logs, :pre_term, :rolling_pre_term, :on_calculation
 
-  self.ram           = 512  # mb
-  self.frequency     = 10   # seconds
+  self.ram = 512  # mb
+  self.frequency = 10   # seconds
   self.percent_usage = 0.99 # percent of RAM to use
   self.rolling_restart_frequency = 6 * 3600 # 6 hours in seconds
   self.rolling_restart_splay_seconds = 0.0..300.0 # 0 to 5 minutes in seconds
@@ -33,15 +33,15 @@ module PumaWorkerKiller
   end
 
   def enable_rolling_restart(frequency = rolling_restart_frequency,
-                             splay_seconds = rolling_restart_splay_seconds)
+    splay_seconds = rolling_restart_splay_seconds)
     # Randomize so all workers don't restart at the exact same time across multiple machines.
     frequency += rand(splay_seconds)
     AutoReap.new(frequency, RollingRestart.new(nil, rolling_pre_term)).start
   end
 end
 
-require 'puma_worker_killer/puma_memory'
-require 'puma_worker_killer/reaper'
-require 'puma_worker_killer/rolling_restart'
-require 'puma_worker_killer/auto_reap'
-require 'puma_worker_killer/version'
+require "puma_worker_killer/puma_memory"
+require "puma_worker_killer/reaper"
+require "puma_worker_killer/rolling_restart"
+require "puma_worker_killer/auto_reap"
+require "puma_worker_killer/version"

--- a/lib/puma_worker_killer/auto_reap.rb
+++ b/lib/puma_worker_killer/auto_reap.rb
@@ -4,7 +4,7 @@ module PumaWorkerKiller
   class AutoReap
     def initialize(timeout, reaper = Reaper.new)
       @timeout = timeout # seconds
-      @reaper  = reaper
+      @reaper = reaper
       @running = false
     end
 

--- a/lib/puma_worker_killer/puma_memory.rb
+++ b/lib/puma_worker_killer/puma_memory.rb
@@ -3,7 +3,7 @@
 module PumaWorkerKiller
   class PumaMemory
     def initialize(master = nil)
-      @master  = master || get_master
+      @master = master || get_master
       @workers = nil
     end
 
@@ -55,7 +55,7 @@ module PumaWorkerKiller
       worker_memory = workers.values.inject(:+) || 0
       worker_memory + master_memory
     end
-    alias get_total_memory get_total
+    alias_method :get_total_memory, :get_total
 
     def workers
       @workers || set_workers
@@ -71,11 +71,11 @@ module PumaWorkerKiller
     # sorted by memory ascending (smallest first, largest last)
     def set_workers
       workers = {}
-      @master.instance_variable_get('@workers').each do |worker|
+      @master.instance_variable_get(:@workers).each do |worker|
         workers[worker] = GetProcessMem.new(worker.pid).mb
       end
       if workers.any?
-        @workers = Hash[workers.sort_by { |_, mem| mem }]
+        @workers = workers.sort_by { |_, mem| mem }.to_h
       else
         {}
       end

--- a/lib/puma_worker_killer/version.rb
+++ b/lib/puma_worker_killer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module PumaWorkerKiller
-  VERSION = '0.3.1'
+  VERSION = "0.3.1"
 end

--- a/puma_worker_killer.gemspec
+++ b/puma_worker_killer.gemspec
@@ -19,10 +19,14 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'get_process_mem',   '~>  0.2'
   gem.add_dependency 'puma',              '>= 2.7'
-  gem.add_development_dependency 'rack', '~> 2.0'
-  gem.add_development_dependency 'rake', '~> 13.0'
-  gem.add_development_dependency 'test-unit', '>= 0'
-  gem.add_development_dependency 'wait_for_it', '~> 0.1'
+  gem.add_dependency 'bigdecimal',        '>= 2.0'
+  gem.add_dependency 'get_process_mem',   '>= 0.2'
+
+
+  gem.add_development_dependency 'rack',        '>= 3.0'
+  gem.add_development_dependency 'rake',        '>= 13.0'
+  gem.add_development_dependency 'rackup',      '>= 2.1'
+  gem.add_development_dependency 'test-unit',   '>= 0'
+  gem.add_development_dependency 'wait_for_it', '>= 0.1'
 end

--- a/puma_worker_killer.gemspec
+++ b/puma_worker_killer.gemspec
@@ -1,31 +1,30 @@
 # frozen_string_literal: true
 
-lib = File.expand_path('lib', __dir__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'puma_worker_killer/version'
+require "puma_worker_killer/version"
 
 Gem::Specification.new do |gem|
-  gem.name          = 'puma_worker_killer'
-  gem.version       = PumaWorkerKiller::VERSION
-  gem.authors       = ['Richard Schneeman']
-  gem.email         = ['richard.schneeman+rubygems@gmail.com']
-  gem.description   = ' Kills pumas, the code kind '
-  gem.summary       = ' If you have a memory leak in your web code puma_worker_killer can keep it in check. '
-  gem.homepage      = 'https://github.com/schneems/puma_worker_killer'
-  gem.license       = 'MIT'
+  gem.name = "puma_worker_killer"
+  gem.version = PumaWorkerKiller::VERSION
+  gem.authors = ["Richard Schneeman"]
+  gem.email = ["richard.schneeman+rubygems@gmail.com"]
+  gem.description = " Kills pumas, the code kind "
+  gem.summary = " If you have a memory leak in your web code puma_worker_killer can keep it in check. "
+  gem.homepage = "https://github.com/schneems/puma_worker_killer"
+  gem.license = "MIT"
 
-  gem.files         = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.require_paths = ['lib']
+  gem.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  gem.require_paths = ["lib"]
 
-  gem.add_dependency 'puma',              '>= 2.7'
-  gem.add_dependency 'bigdecimal',        '>= 2.0'
-  gem.add_dependency 'get_process_mem',   '>= 0.2'
+  gem.add_dependency "puma", ">= 2.7"
+  gem.add_dependency "bigdecimal", ">= 2.0"
+  gem.add_dependency "get_process_mem", ">= 0.2"
 
-  gem.add_development_dependency 'rack',        '>= 3.0'
-  gem.add_development_dependency 'rake',        '>= 13.0'
-  gem.add_development_dependency 'rackup',      '>= 2.1'
-  gem.add_development_dependency 'test-unit',   '>= 0'
-  gem.add_development_dependency 'wait_for_it', '>= 0.1'
+  gem.add_development_dependency "rack", ">= 3.0"
+  gem.add_development_dependency "rake", ">= 13.0"
+  gem.add_development_dependency "rackup", ">= 2.1"
+  gem.add_development_dependency "test-unit", ">= 0"
+  gem.add_development_dependency "wait_for_it", ">= 0.1"
 end

--- a/puma_worker_killer.gemspec
+++ b/puma_worker_killer.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.homepage = "https://github.com/schneems/puma_worker_killer"
   gem.license = "MIT"
 
-  gem.files = `git ls-files`.split($INPUT_RECORD_SEPARATOR)
+  gem.files = `git ls-files`.split($/)
   gem.executables = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.require_paths = ["lib"]
 

--- a/puma_worker_killer.gemspec
+++ b/puma_worker_killer.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'bigdecimal',        '>= 2.0'
   gem.add_dependency 'get_process_mem',   '>= 0.2'
 
-
   gem.add_development_dependency 'rack',        '>= 3.0'
   gem.add_development_dependency 'rake',        '>= 13.0'
   gem.add_development_dependency 'rackup',      '>= 2.1'

--- a/test/fixtures/big.ru
+++ b/test/fixtures/big.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-load File.expand_path('fixture_helper.rb', __dir__)
+load File.expand_path("fixture_helper.rb", __dir__)
 
 PumaWorkerKiller.start
 

--- a/test/fixtures/config/puma_worker_killer_start.rb
+++ b/test/fixtures/config/puma_worker_killer_start.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
-load File.expand_path('../fixture_helper.rb', __dir__)
+load File.expand_path("../fixture_helper.rb", __dir__)
 
 before_fork do
-  require 'puma_worker_killer'
+  require "puma_worker_killer"
   PumaWorkerKiller.start
 end

--- a/test/fixtures/default.ru
+++ b/test/fixtures/default.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-load File.expand_path('fixture_helper.rb', __dir__)
+load File.expand_path("fixture_helper.rb", __dir__)
 
 PumaWorkerKiller.start
 

--- a/test/fixtures/fixture_helper.rb
+++ b/test/fixtures/fixture_helper.rb
@@ -1,22 +1,22 @@
 # frozen_string_literal: true
 
-require 'securerandom'
+require "securerandom"
 
-require 'rack'
-require 'rackup/server'
+require "rack"
+require "rackup/server"
 
-require 'puma_worker_killer'
+require "puma_worker_killer"
 
 PumaWorkerKiller.config do |config|
-  config.ram       = Integer(ENV['PUMA_RAM'])       if ENV['PUMA_RAM']
-  config.frequency = Integer(ENV['PUMA_FREQUENCY']) if ENV['PUMA_FREQUENCY']
+  config.ram = Integer(ENV["PUMA_RAM"]) if ENV["PUMA_RAM"]
+  config.frequency = Integer(ENV["PUMA_FREQUENCY"]) if ENV["PUMA_FREQUENCY"]
 end
 
-puts "Frequency: #{PumaWorkerKiller.frequency}" if ENV['PUMA_FREQUENCY']
+puts "Frequency: #{PumaWorkerKiller.frequency}" if ENV["PUMA_FREQUENCY"]
 
 class HelloWorld
   def response(_env)
-    [200, {}, ['Hello World']]
+    [200, {}, ["Hello World"]]
   end
 end
 

--- a/test/fixtures/fixture_helper.rb
+++ b/test/fixtures/fixture_helper.rb
@@ -3,7 +3,7 @@
 require 'securerandom'
 
 require 'rack'
-require 'rack/server'
+require 'rackup/server'
 
 require 'puma_worker_killer'
 

--- a/test/fixtures/on_calculation.ru
+++ b/test/fixtures/on_calculation.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-load File.expand_path('fixture_helper.rb', __dir__)
+load File.expand_path("fixture_helper.rb", __dir__)
 
 PumaWorkerKiller.config do |config|
   config.on_calculation = ->(usage) { puts("Current memory footprint: #{usage} mb") }

--- a/test/fixtures/pre_term.ru
+++ b/test/fixtures/pre_term.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-load File.expand_path('fixture_helper.rb', __dir__)
+load File.expand_path("fixture_helper.rb", __dir__)
 
 PumaWorkerKiller.config do |config|
   config.pre_term = ->(worker) { puts("About to terminate worker: #{worker.inspect}") }

--- a/test/fixtures/rolling_pre_term.ru
+++ b/test/fixtures/rolling_pre_term.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-load File.expand_path('fixture_helper.rb', __dir__)
+load File.expand_path("fixture_helper.rb", __dir__)
 
 PumaWorkerKiller.config do |config|
   config.rolling_pre_term = ->(worker) { puts("About to terminate (rolling) worker: #{worker.pid}") }

--- a/test/fixtures/rolling_restart.ru
+++ b/test/fixtures/rolling_restart.ru
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-load File.expand_path('fixture_helper.rb', __dir__)
+load File.expand_path("fixture_helper.rb", __dir__)
 
 PumaWorkerKiller.enable_rolling_restart(1, 0..5.0) # 1 second, short 1-5s splay.
 

--- a/test/puma_worker_killer_test.rb
+++ b/test/puma_worker_killer_test.rb
@@ -1,60 +1,60 @@
 # frozen_string_literal: true
 
-require 'test_helper'
+require "test_helper"
 
 class PumaWorkerKillerTest < Test::Unit::TestCase
   def test_starts
-    port     = 0 # http://stackoverflow.com/questions/200484/how-do-you-find-a-free-tcp-server-port-using-ruby
-    command  = "bundle exec puma #{fixture_path.join("default.ru")} -t 1:1 -w 2 --preload --debug -p #{port}"
-    options  = { wait_for: 'booted', timeout: 5, env: { 'PUMA_FREQUENCY' => 1 } }
+    port = 0 # http://stackoverflow.com/questions/200484/how-do-you-find-a-free-tcp-server-port-using-ruby
+    command = "bundle exec puma #{fixture_path.join("default.ru")} -t 1:1 -w 2 --preload --debug -p #{port}"
+    options = {wait_for: "booted", timeout: 5, env: {"PUMA_FREQUENCY" => 1}}
 
     WaitForIt.new(command, options) do |spawn|
-      assert_contains(spawn, 'PumaWorkerKiller')
+      assert_contains(spawn, "PumaWorkerKiller")
     end
   end
 
   def test_without_preload
-    port     = 0 # http://stackoverflow.com/questions/200484/how-do-you-find-a-free-tcp-server-port-using-ruby
-    command  = "bundle exec puma #{fixture_path.join("default.ru")} -t 1:1 -w 2 --debug -p #{port} -C #{fixture_path.join("config/puma_worker_killer_start.rb")}"
-    options  = { wait_for: 'booted', timeout: 10, env: { 'PUMA_FREQUENCY' => 1 } }
+    port = 0 # http://stackoverflow.com/questions/200484/how-do-you-find-a-free-tcp-server-port-using-ruby
+    command = "bundle exec puma #{fixture_path.join("default.ru")} -t 1:1 -w 2 --debug -p #{port} -C #{fixture_path.join("config/puma_worker_killer_start.rb")}"
+    options = {wait_for: "booted", timeout: 10, env: {"PUMA_FREQUENCY" => 1}}
 
     WaitForIt.new(command, options) do |spawn|
-      assert_contains(spawn, 'PumaWorkerKiller')
+      assert_contains(spawn, "PumaWorkerKiller")
     end
   end
 
   def test_kills_large_app
-    file     = fixture_path.join('big.ru')
-    port     = 0
-    command  = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
-    options  = { wait_for: 'booted', timeout: 5, env: { 'PUMA_FREQUENCY' => 1, 'PUMA_RAM' => 1 } }
+    file = fixture_path.join("big.ru")
+    port = 0
+    command = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
+    options = {wait_for: "booted", timeout: 5, env: {"PUMA_FREQUENCY" => 1, "PUMA_RAM" => 1}}
 
     WaitForIt.new(command, options) do |spawn|
-      assert_contains(spawn, 'Out of memory')
+      assert_contains(spawn, "Out of memory")
     end
   end
 
   def test_pre_term
-    file     = fixture_path.join('pre_term.ru')
-    port     = 0
-    command  = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
-    options  = { wait_for: 'booted', timeout: 5, env: { 'PUMA_FREQUENCY' => 1, 'PUMA_RAM' => 1 } }
+    file = fixture_path.join("pre_term.ru")
+    port = 0
+    command = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
+    options = {wait_for: "booted", timeout: 5, env: {"PUMA_FREQUENCY" => 1, "PUMA_RAM" => 1}}
 
     WaitForIt.new(command, options) do |spawn|
-      assert_contains(spawn, 'Out of memory')
-      assert_contains(spawn, 'About to terminate worker:') # defined in pre_term.ru
+      assert_contains(spawn, "Out of memory")
+      assert_contains(spawn, "About to terminate worker:") # defined in pre_term.ru
     end
   end
 
   def test_on_calculation
-    file     = fixture_path.join('on_calculation.ru')
-    port     = 0
-    command  = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
-    options  = { wait_for: 'booted', timeout: 5, env: { 'PUMA_FREQUENCY' => 1, 'PUMA_RAM' => 1 } }
+    file = fixture_path.join("on_calculation.ru")
+    port = 0
+    command = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
+    options = {wait_for: "booted", timeout: 5, env: {"PUMA_FREQUENCY" => 1, "PUMA_RAM" => 1}}
 
     WaitForIt.new(command, options) do |spawn|
-      assert_contains(spawn, 'Out of memory')
-      assert_contains(spawn, 'Current memory footprint:') # defined in on_calculate.ru
+      assert_contains(spawn, "Out of memory")
+      assert_contains(spawn, "Current memory footprint:") # defined in on_calculate.ru
     end
   end
 
@@ -63,23 +63,23 @@ class PumaWorkerKillerTest < Test::Unit::TestCase
   end
 
   def test_rolling_restart
-    file     = fixture_path.join('rolling_restart.ru')
-    port     = 0
-    command  = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
+    file = fixture_path.join("rolling_restart.ru")
+    port = 0
+    command = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
     puts command.inspect
-    options = { wait_for: 'booted', timeout: 15, env: {} }
+    options = {wait_for: "booted", timeout: 15, env: {}}
 
     WaitForIt.new(command, options) do |spawn|
-      assert_contains(spawn, 'Rolling Restart')
+      assert_contains(spawn, "Rolling Restart")
     end
   end
 
   def test_rolling_restart_worker_kill_check
-    file     = fixture_path.join('rolling_restart.ru')
-    port     = 0
-    command  = "bundle exec puma #{file} -t 1:1 -w 1 --preload --debug -p #{port}"
+    file = fixture_path.join("rolling_restart.ru")
+    port = 0
+    command = "bundle exec puma #{file} -t 1:1 -w 1 --preload --debug -p #{port}"
     puts command.inspect
-    options = { wait_for: 'booted', timeout: 120, env: {} }
+    options = {wait_for: "booted", timeout: 120, env: {}}
 
     WaitForIt.new(command, options) do |spawn|
       # at least 2 matches for TERM (so we set a timeout value longer - 120sec)
@@ -90,15 +90,15 @@ class PumaWorkerKillerTest < Test::Unit::TestCase
   end
 
   def test_rolling_pre_term
-    file     = fixture_path.join('rolling_pre_term.ru')
-    port     = 0
-    command  = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
+    file = fixture_path.join("rolling_pre_term.ru")
+    port = 0
+    command = "bundle exec puma #{file} -t 1:1 -w 2 --preload --debug -p #{port}"
     puts command.inspect
-    options = { wait_for: 'booted', timeout: 15, env: {} }
+    options = {wait_for: "booted", timeout: 15, env: {}}
 
     WaitForIt.new(command, options) do |spawn|
-      assert_contains(spawn, 'Rolling Restart')
-      assert_contains(spawn, 'About to terminate (rolling) worker:') # defined in rolling_pre_term.ru
+      assert_contains(spawn, "Rolling Restart")
+      assert_contains(spawn, "About to terminate (rolling) worker:") # defined in rolling_pre_term.ru
     end
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,10 +2,10 @@
 
 Bundler.require
 
-require 'puma_worker_killer'
-require 'test/unit'
-require 'wait_for_it'
+require "puma_worker_killer"
+require "test/unit"
+require "wait_for_it"
 
 def fixture_path
-  Pathname.new(File.expand_path('fixtures', __dir__))
+  Pathname.new(File.expand_path("fixtures", __dir__))
 end


### PR DESCRIPTION
There's no reason to block pessimistically (`~>`) to any of these versions. Also add dependencies (bigdecimal) which is warned about in a deprecation warning:

```
/Users/rschneeman/.gem/ruby/3.3.1/gems/get_process_mem-0.2.7/lib/get_process_mem.rb:2: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec. Also contact author of get_process_mem-0.2.7 to add bigdecimal into its gemspec.
```